### PR TITLE
HP-24 - create a vagrant file that set up ubuntu machines with appropriate IP-addresses and ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vagrant/.vagrant
+sprint_1/T_Andreiko/vagrant-vm-config/inventory.ini

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,0 +1,64 @@
+# Vagrant Infrastructure Setup
+
+## Project Overview
+This project provisions an infrastructure of **three virtual machines** using **Vagrant** and **VirtualBox**.  
+The goal is to provide a ready-to-use environment for testing, development, and automation with **Ansible**.
+
+The infrastructure consists of:
+
+- **Flask Server (Web Server)**  
+  Runs a Python Flask application and acts as the main entry point for client requests.  
+  It simulates a production-like web service environment.
+
+- **PostgreSQL Server (Database)**  
+  Provides a PostgreSQL database backend for the Flask application.  
+  It is preconfigured to be accessible from the web server and optimized for local development.
+
+- **Load Balancer Server**  
+  Balances traffic between multiple web servers (currently a single Flask server, but can be scaled).  
+  Useful for simulating high availability and scaling scenarios.
+---
+
+## Structure
+- `Vagrantfile` — main configuration file for setting up the infrastructure.  
+- `inventory.ini` — automatically generated Ansible inventory file for managing virtual machines.  
+- `build_installer.sh` — script that creates a self-extracting installer (executed during `vagrant up`).  
+
+---
+
+
+### Start the Infrastructure
+```bash
+vagrant up
+```
+
+### Check VM Status
+```bash
+vagrant status
+```
+
+### Connection to VB usig SSH
+```bash
+vagrant ssh server
+```
+
+```bash
+vagrant ssh database
+```
+
+```bash
+vagrant ssh load_balancer
+```
+
+
+### Stop all machines
+
+```bash
+vagrant halt
+```
+
+### Destroy all machines
+
+```-bash
+vagrant destroy -f
+```

--- a/vagrant/VagrantFile
+++ b/vagrant/VagrantFile
@@ -1,0 +1,88 @@
+
+
+Vagrant.configure("2") do |config|
+
+
+
+  # ---------------- IP-addresses and ports ----------------
+  SERVER_IP             = ENV['SERVER_IP']              || "192.168.56.110"
+  DATABASE_IP           = ENV['DATABASE_IP']            || "192.168.56.111"
+  LOAD_BALANCER_IP      = ENV['LOAD_BALANCER_IP']       || "192.168.56.112"
+
+  SERVER_PORT           = ENV['SERVER_PORT']            || 8080
+  DATABASE_PORT         = ENV['DATABASE_PORT']          || 5432
+  LOAD_BALANCER_PORT    = ENV['LOAD_BALANCER_PORT']     || 80
+
+
+
+  # ---------------- SERVER ----------------
+
+  config.vm.define "server" do |server|
+    server.vm.box = "bento/ubuntu-24.04"
+    server.vm.network "private_network", ip: SERVER_IP
+    server.vm.network "forwarded_port", guest: 80, host: SERVER_PORT
+
+    server.vm.provider "virtualbox" do |vb|
+      vb.name = "Flask Server"
+      vb.memory = 2048
+      vb.cpus = 2
+    end
+
+  end
+
+
+
+  # ---------------- DATABASE ----------------
+
+  config.vm.define "database" do |db|
+    db.vm.box = "bento/ubuntu-24.04"
+    db.vm.network "private_network", ip: DATABASE_IP
+    db.vm.network "forwarded_port", guest: 5432, host: DATABASE_PORT
+
+    db.vm.provider "virtualbox" do |vb|
+      vb.name = "PostgreSQL Server"
+      vb.memory = 2048
+      vb.cpus = 2
+    end
+
+  end
+
+
+
+  # ---------------- LOAD BALANCER ----------------
+
+  config.vm.define "load_balancer" do |lb|
+    lb.vm.box = "bento/ubuntu-24.04"
+    lb.vm.network "private_network", ip: LOAD_BALANCER_IP
+    lb.vm.network "forwarded_port", guest: 80, host: LOAD_BALANCER_PORT
+
+    lb.vm.provider "virtualbox" do |vb|
+      vb.name = "Load Balancer Server"
+      vb.memory = 2048
+      vb.cpus = 2
+    end
+
+  end
+
+
+
+  # ---------------- Configure inventory.ini file ----------------
+  config.vm.provision "shell", run: "always", inline: <<-SHELL
+    cat > /vagrant/inventory.ini <<EOF
+[web-server]
+#{SERVER_IP} ansible_user=vagrant ansible_ssh_private_key_file=/home/jenkins/keys/private_key_server ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+
+[database]
+#{DATABASE_IP} ansible_user=vagrant ansible_ssh_private_key_file=/home/jenkins/keys/private_key_database ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+
+[load-balancer]
+#{LOAD_BALANCER_IP} ansible_user=vagrant ansible_ssh_private_key_file=/home/jenkins/keys/private_key_load_balancer ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+EOF
+  SHELL
+
+
+
+  # ---------------- Create self-extracting installer ----------------
+  config.vm.provision "shell", run: "always", path: "build_installer.sh"
+
+end 


### PR DESCRIPTION
## What was done in PR?
Realized a Vagrant file configuration for provisioning an infrastructure of three virtual machines using VirtualBox:
1. Flask Server (server)
2. PostgreSQL Server (database)
3. Load Balancer Server (load_balancer)


## Why this PR is required?
1. Provide a ready-to-use development environment for the Flask application with its supporting PostgreSQL database and load balancer.
2. Automatically generate an Ansible inventory, reducing manual setup and potential errors when configuring servers

## How to validate this PR?
1. Start the Infrastructure
```bash
vagrant up
```

2. Check VM Status
```bash
vagrant status
```
3. Connection to VB usig SSH
```bash
vagrant ssh server
```

## Additional information
1. All VMs are configured with 2 CPUs and 2GB RAM by default; these can be adjusted in the Vagrantfile.
2. The Ansible inventory references private keys in `/home/jenkins/keys/`; adjust these paths if running outside a CI environment.