### PR TITLE
HP-27_create_scripts_that_configures_all_the_necessary_files_for_Ansible_on_Jenkins_VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 vagrant/.vagrant
-sprint_1/T_Andreiko/vagrant-vm-config/inventory.ini
+
+
+vagrant/inventory.ini
+vagrant/scripts/jenkins_makeself.sh

--- a/vagrant/scripts/build_installer.sh
+++ b/vagrant/scripts/build_installer.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+
+VAGRANT_DIR="/vagrant"
+BUILD_DIR="/tmp/jenkins_package"
+INSTALLER="$VAGRANT_DIR/scripts/jenkins_makeself.sh"
+
+
+echo "*** Preparing package directory..."
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+
+
+# ---------------- Copy all private keys ----------------
+for MACHINE in $(ls -1 "$VAGRANT_DIR/.vagrant/machines"); do
+  KEY_PATH="$VAGRANT_DIR/.vagrant/machines/$MACHINE/virtualbox/private_key"
+
+  if [[ -f "$KEY_PATH" ]]; then
+    cp "$KEY_PATH" "$BUILD_DIR/private_key_$MACHINE"
+
+  else
+    echo "Warning: Private key for $MACHINE not found!"
+  fi
+done
+
+
+# ---------------- Copy inventory.ini ----------------
+if [[ -f "$VAGRANT_DIR/inventory.ini" ]]; then
+  cp "$VAGRANT_DIR/inventory.ini" "$BUILD_DIR/"
+
+else
+  echo "Warning: inventory.ini not found!"
+fi
+
+
+# ---------------- Copy install.sh ----------------
+if [[ ! -f "$VAGRANT_DIR/scripts/install.sh" ]]; then
+  echo "Error: install.sh not found in $VAGRANT_DIR"
+  exit 1
+fi
+
+cp "$VAGRANT_DIR/scripts/install.sh" "$BUILD_DIR/install.sh"
+chmod +x "$BUILD_DIR/install.sh"
+
+
+# ---------------- Install makeself if missing ----------------
+if ! command -v makeself &> /dev/null; then
+  sudo apt-get update -y
+  sudo apt-get install -y makeself
+fi
+
+
+# ---------------- Generate self-extracting installer ----------------
+makeself "$BUILD_DIR" "$INSTALLER" "Jenkins config installer" ./install.sh
+chmod +x "$INSTALLER"
+
+echo "*** Installer created at $INSTALLER"

--- a/vagrant/scripts/install.sh
+++ b/vagrant/scripts/install.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+
+INSTALL_DIR="/home/jenkins"
+KEYS_DIR="$INSTALL_DIR/keys"
+
+
+echo "*** Installing Jenkins config..."
+mkdir -p "$KEYS_DIR"
+
+
+# ---------------- Install all private keys ----------------
+for KEY in private_key_*; do
+  if [[ -f "$KEY" ]]; then
+    cp "$KEY" "$KEYS_DIR/$KEY"
+    chmod 600 "$KEYS_DIR/$KEY"
+    echo "  -> Installed $KEY into $KEYS_DIR"
+  fi
+done
+
+
+# ---------------- Install inventory.ini ----------------
+if [[ -f "inventory.ini" ]]; then
+  cp inventory.ini "$INSTALL_DIR/inventory.ini"
+  chmod 644 "$INSTALL_DIR/inventory.ini"
+  echo "  -> Installed inventory.ini into $INSTALL_DIR"
+fi
+
+echo "*** Done!"


### PR DESCRIPTION
## What was done in PR?
1.  Create **_build_installer.sh_** script that:
  - Collects all necessary files for Ansible execution on the Jenkins VM (private keys, inventory.ini)
  - Creates a self-extracting installer (**_jenkins_makeself.sh_**) that can be easily transferred and executed
2. Create _**install.sh**_ script that:
  - Extracts files from the generated installer.
  - Installs private keys into `/home/jenkins/keys/`
  - Installs inventory.ini into `/home/jenkins/`
  - Sets correct permissions with `chmod` on keys and configs.

## Why this PR is required?
  - Automates the packaging and installation of Ansible configuration files for Jenkins.
  - Simplifies provisioning by bundling all dependencies (keys, inventory, configs) into a single self-extracting installer.
  - Reduces manual steps when preparing the Jenkins VM for Ansible runs.

## How to validate this PR?

### 1. Run the build script inside the Vagrant environment

```bash
vagrant ssh
cd /vagrant/scripts
./build_installer.sh
```
### 2. Run the generated installer:

```bash
./jenkins_makeself.sh
```
## Additional information
Designed to be extendable: additional config files can be added into build_installer.sh without changing the installation flow.
