### PR TITLE
HP-28-implement Jenkins files with pipelines for running Ansible playbooks

### DIFF
--- a/jenkins/JenkinsFile
+++ b/jenkins/JenkinsFile
@@ -1,0 +1,28 @@
+pipeline {
+
+  agent any
+
+  stages {
+
+    stage('Configure PostgreSQL database') {
+
+      steps {
+        build job: 'db_pipeline', wait: true
+      }
+    }
+
+    stage('Configure Flask server') {
+
+      steps {
+        build job: 'server_pipeline', wait: true
+      }
+    }
+
+    stage('Configure Load Balancer server') {
+
+      steps {
+        build job: 'lb_pipeline', wait: true
+      }
+    }
+  }
+}

--- a/jenkins/deploys/ansible/database/JenkinsFile
+++ b/jenkins/deploys/ansible/database/JenkinsFile
@@ -1,0 +1,36 @@
+pipeline {
+
+  agent any
+
+  environment {
+    DB_PASSWORD = credentials('db_password')
+  }
+
+  stages {
+
+    stage('Checkout') {
+
+      steps {
+        checkout scm
+      }
+    }
+
+    stage('Run Ansible') {
+
+      steps {
+
+        sshagent(credentials: ['db']) {
+
+          sh '''
+            ansible-galaxy collection install -r ansible/collections/requirements.yml --force
+
+            export ANSIBLE_HOST_KEY_CHECKING=False
+            ansible-playbook -i ansible/inventory.ini ansible/db.yml \
+              -e db_password="$DB_PASSWORD"
+          '''
+          
+        }
+      }
+    }
+  }
+}

--- a/jenkins/deploys/ansible/load-balancer/JenkinsFile
+++ b/jenkins/deploys/ansible/load-balancer/JenkinsFile
@@ -1,0 +1,29 @@
+pipeline {
+
+  agent any
+
+  stages {
+
+    stage('Checkout') {
+
+      steps {
+
+        checkout scm
+      }
+    }
+
+    stage('Run Ansible') {
+
+      steps {
+
+        sshagent(credentials: ['load_balancer']) {
+          
+          sh '''
+            export ANSIBLE_HOST_KEY_CHECKING=False
+            ansible-playbook -i ansible/inventory.ini ansible/lb.yml
+          '''
+        }
+      }
+    }
+  }
+}

--- a/jenkins/deploys/ansible/web-server/JenkinsFile
+++ b/jenkins/deploys/ansible/web-server/JenkinsFile
@@ -1,0 +1,34 @@
+pipeline {
+
+  agent any
+
+  environment {
+    DB_PASSWORD = credentials('db_password')
+  }
+
+  stages {
+
+    stage('Checkout') {
+
+      steps { 
+        checkout scm 
+      }
+    }
+
+    stage('Run Ansible') {
+
+      steps {
+
+        sshagent(credentials: ['server', 'server2']) {
+          
+          sh '''
+            export ANSIBLE_HOST_KEY_CHECKING=False
+
+            ansible-playbook -i ansible/inventory.ini ansible/flask.yml \
+              -e db_password="$DB_PASSWORD"
+          '''
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What was done in PR?
#### Created a main deployment pipeline (Jenkinsfile) that orchestrates three jobs:
1. `db_pipeline` – sets up PostgreSQL database
2. `server_pipeline` – deploys Flask web server
3. `lb_pipeline` – configures load balancer
#### Configured credential management:
1. DB and server credentials stored in Jenkins
2. Used sshagent for secure Ansible SSH connections

## Why this PR is required?
1. To automate deployment of the entire infrastructure (DB, web servers, load balancer) via Jenkins.
2. Ensures reproducible, consistent deployment using Ansible
3. Removes the need for manual setup and reduces human error
4. Integrates secure credential handling into Jenkins pipelines

## How to validate this PR?
#### Trigger the main pipeline in Jenkins

#### Verify that each stage completes successfully:
1. Configure `PostgreSQL database` → DB deployed and accessible
2. Configure `Flask server` → Web server is up and connected to DB
3. Configure `Load Balancer server` → LB configured and traffic routed correctly

#### Check Jenkins console logs for successful Ansible playbook execution

#### Optionally, validate credentials usage by checking that DB password is injected correctly


## Additional information
This PR sets the foundation for scalable CI/CD deployment of the application
