### PR TITLE
HP-47-implement Jenkins file to deploy and build an Ubuntu image using Packer

### DIFF
--- a/jenkins/deploys/packer/vagrant/JenkinsFile
+++ b/jenkins/deploys/packer/vagrant/JenkinsFile
@@ -1,0 +1,31 @@
+pipeline {
+
+    agent any
+
+    environment {
+        PACKER_PLUGIN_PATH = "${env.HOME}/.packer.d/plugins"
+    }
+
+    stages {
+
+        stage('Compile Packer fileile') {
+            steps {
+                withCredentials([file(credentialsId: 'Packer-ubuntu-ssh-private-key', variable: 'SSH_KEY')]) {
+                    sh '''
+                        packer init packer/build-ubuntu-box.pkr.hcl
+                    '''
+                }
+            }
+        }
+
+        stage('Build Packer file') {
+            steps {
+                withCredentials([file(credentialsId: 'Packer-ubuntu-ssh-private-key', variable: 'SSH_KEY')]) {
+                    sh '''
+                        packer build -var ssh_private_key_file=$SSH_KEY packer/build-ubuntu-box.pkr.hcl
+                    '''
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What was done in PR?
Implemented Jenkins file pipeline to run and configure Packer file - `build-ubuntu-box.pkr.hcl` for installetion, building, deploying and pushing vagrant box to Hashicorp cloud

## Why this PR is required?
To automatically set up virtual machines by own box iso using Vagrant

## How to validate this PR?
Login to jenkins admin panel - add GitHub configuration of the repository, configuration of pipeline and running

## Additional information
Make sure that on your Jenkins server(virtual machine) is already installed: 
1. Packer
2. Packer tools(vagrant plugin)
3. Virtual Box
