### PR TITLE
HP-54-write terraform to build backend servers on ec2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ vagrant/scripts/jenkins_makeself.sh
 
 
 packer/packer_cache/
+
+
+terraform/deploy-servers/.terraform/
+terraform/deploy-servers/.terraform.lock.hcl
+terraform/deploy-servers/terraform.tfstate
+terraform/deploy-servers/terraform.tfstate.backup

--- a/terraform/deploy-servers/main.tf
+++ b/terraform/deploy-servers/main.tf
@@ -1,0 +1,64 @@
+
+provider "aws" {
+  region = "eu-north-1"
+}
+
+
+resource "aws_instance" "database" {
+  ami                    = "ami-0a410d510ebdc48ba"
+  instance_type          = "t3.micro"
+  subnet_id              = var.subnet_ids[0]
+  key_name               = var.key_name
+  vpc_security_group_ids = [var.security_group_id]
+
+  associate_public_ip_address = false
+
+  tags = {
+    Name = "Database"
+  }
+}
+
+
+resource "aws_instance" "flask" {
+  ami                    = "ami-08a686a69a7bf216e"
+  instance_type          = "t3.micro"
+  subnet_id              = var.subnet_ids[1]
+  key_name               = var.key_name
+  vpc_security_group_ids = [var.security_group_id]
+
+  associate_public_ip_address = false
+
+  tags = {
+    Name = "Flask Server"
+  }
+}
+
+
+resource "aws_instance" "loadbalancer" {
+  ami                         = "ami-0a410d510ebdc48ba"
+  instance_type               = "t3.micro"
+  subnet_id                   = var.public_subnet_id  
+  key_name                    = var.key_name
+  vpc_security_group_ids      = [var.security_group_id]
+
+  associate_public_ip_address = true  
+
+  tags = {
+    Name = "Load Balancer"
+  }
+}
+
+
+resource "aws_instance" "consul" {
+  ami                    = "ami-0a410d510ebdc48ba"
+  instance_type          = "t3.micro"
+  subnet_id              = var.subnet_ids[3]
+  key_name               = var.key_name
+  vpc_security_group_ids = [var.security_group_id]
+
+  associate_public_ip_address = false
+  
+  tags = {
+    Name = "Consul"
+  }
+}

--- a/terraform/deploy-servers/outputs.tf
+++ b/terraform/deploy-servers/outputs.tf
@@ -1,0 +1,17 @@
+
+output "database_private_ip" {
+  value = aws_instance.database.private_ip
+}
+
+output "flask_private_ip" {
+  value = aws_instance.flask.private_ip
+}
+
+output "loadbalancer_private_ip" {
+  value = aws_instance.loadbalancer.private_ip
+}
+
+output "consul_private_ip" {
+  value = aws_instance.consul.private_ip
+}
+

--- a/terraform/deploy-servers/terraform.tfvars
+++ b/terraform/deploy-servers/terraform.tfvars
@@ -1,6 +1,6 @@
 vpc_id = "vpc-07a0027f69f58511f"
 subnet_ids = ["subnet-04d98f3b466cf716e","subnet-01759bf68fff88f84","subnet-08c44128f5f11ead7", "subnet-0d27e78a4c58ab466"]
-key_name = "Tsymbalistyi_M"
+key_name = "grantAdminKey"
 security_group_id = "sg-05751e20e62ab575b"
 
 

--- a/terraform/deploy-servers/terraform.tfvars
+++ b/terraform/deploy-servers/terraform.tfvars
@@ -1,0 +1,7 @@
+vpc_id = "vpc-07a0027f69f58511f"
+subnet_ids = ["subnet-04d98f3b466cf716e","subnet-01759bf68fff88f84","subnet-08c44128f5f11ead7", "subnet-0d27e78a4c58ab466"]
+key_name = "Tsymbalistyi_M"
+security_group_id = "sg-05751e20e62ab575b"
+
+
+public_subnet_id = "subnet-0bc652a7f0a0292f6" 

--- a/terraform/deploy-servers/variables.tf
+++ b/terraform/deploy-servers/variables.tf
@@ -1,0 +1,25 @@
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID where to create private EC2"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Three private subnet IDs"
+}
+
+variable "key_name" {
+  type        = string
+  description = "SSH key name"
+}
+
+variable "security_group_id" {
+  type        = string
+  description = "Security group ID for private servers"
+}
+
+variable "public_subnet_id" {
+  type        = string
+  description = "Public subnet ID for Load Balancer"
+}


### PR DESCRIPTION
## What was done in PR?
#### 1. Created EC2 instances:
        1.     database (private)
        2.     flask (private)
        3.     consul (private)
        4.     loadbalancer (public)
#### 2. Defined variables in variables.tf for:
        1.   VPC ID, subnet IDs, key name, security group ID, and public subnet.
        2.   Added outputs in `outputs.tf` to expose each instance’s private IP address.
        3.   Added configuration file terraform.tfvars with example/test values.
#### 3. Configured AWS provider for region `eu-north-1`.

## Why this PR is required?
#### This PR is necessary to:
1. Introduce automated provisioning of core EC2 servers (database, Flask app, Consul, and load balancer).
2. Enable modular, repeatable, and scalable infrastructure deployment.

## How to validate this PR?
#### 1. Initialize Terraform:
```
cd terraform/deploy-servers
terraform init
```
2. #### Validate syntax:
`terraform validate`

#### 3. Apply to deploy infrastructure:
`terraform apply`

## Additional information
