### PR TITLE
HP-58 Add consul playbooks

### DIFF
--- a/ansible/consul.yml
+++ b/ansible/consul.yml
@@ -1,0 +1,51 @@
+---
+- name: Push Consul config (SERVER) and restart service
+  hosts: consul
+  become: true
+
+  tasks:
+    - name: Ensure config and data directories exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0750"
+        owner: consul
+        group: consul
+      loop:
+        - /etc/consul.d
+        - /var/lib/consul
+    
+    - name: Drop /etc/consul.d/consul.hcl (SERVER)
+      copy:
+        dest: /etc/consul.d/consul.hcl
+        owner: consul
+        group: consul
+        mode: "0640"
+        content: |
+          datacenter  = "my-dc-1"
+          data_dir    = "/var/lib/consul"
+          client_addr = "0.0.0.0"
+
+          ui_config {
+            enabled = true
+          }
+
+          bind_addr      = "0.0.0.0"
+          advertise_addr = "10.0.2.10"
+
+          server           = true
+          bootstrap_expect = 1
+      notify: Restart consul
+    
+    - name: Ensure consul service is enabled and running
+      ansible.builtin.systemd:
+        name: consul
+        enabled: true
+        state: started
+      
+  handlers:
+    - name: Restart consul
+      service:
+        name: consul
+        state: restarted
+        enabled: true

--- a/ansible/flask.yml
+++ b/ansible/flask.yml
@@ -72,6 +72,55 @@
         mode: "0644"
       notify: Reload nginx
 
+    - name: Ensure config and data directories exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0750"
+        owner: consul
+        group: consul
+      loop:
+        - /etc/consul.d
+        - /var/lib/consul
+    
+    - name: Drop /etc/consul.d/consul.hcl (SERVER)
+      copy:
+        dest: /etc/consul.d/consul.hcl
+        owner: consul
+        group: consul
+        mode: "0640"
+        content: |
+          datacenter = "my-dc-1"
+          
+          data_dir = "/opt/consul"
+          
+          client_addr = "0.0.0.0"
+          
+          ui_config {
+            enabled = true
+          }
+          
+          service {
+            name = "frontend" # name of the service, must be the same on frontend VMs
+            id   = "frontend-{id}" # must be unique, like name of vm
+            port = 80
+          }
+          
+          server = false
+          
+          bind_addr = "[::]" # Listen on all IPv6
+          bind_addr = "0.0.0.0" # Listen on all IPv4
+          
+          advertise_addr = "ip_addr" # theres have to be private ip of vm
+          retry_join = ["consul.service.consul"]
+      notify: Restart consul  
+
+    - name: Ensure consul service is enabled and running
+      ansible.builtin.systemd:
+        name: consul
+        enabled: true
+        state: started  
+
   handlers:
     - name: Reload nginx
       ansible.builtin.systemd:
@@ -81,3 +130,8 @@
     - name: Reload systemd
       ansible.builtin.systemd:
         daemon_reload: true
+    
+    - name: Restart consul
+      ansible.builtin.systemd:
+        name: consul
+        state: restarted    

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -4,7 +4,7 @@ app_env_file: /opt/flaskapp/.env
 app_bind: 0.0.0.0:8000
 gunicorn_workers: 2
 app_module: app:app
-db_host: 192.168.178.111
+db_host: 10.0.2.248
 db_name: bird
 db_user: flask
-pg_allowed_net: 192.168.178.0/24
+pg_allowed_net: 10.0.0.0/8

--- a/ansible/lb.yml
+++ b/ansible/lb.yml
@@ -3,6 +3,7 @@
   hosts: load_balancer
   remote_user: root
   become: yes
+
   tasks:
     - name: Ensure that nginx is installed
       ansible.builtin.apt:
@@ -16,18 +17,119 @@
         state: started
         enabled: true
 
-    - name: Deploy Nginx load balancer config
-      ansible.builtin.template:
-        src: lb.conf.j2
-        dest: /etc/nginx/sites-enabled/lb.conf
-        mode: "0644"
-      notify: Reload nginx
-
     - name: Remove default site
       ansible.builtin.file:
         path: /etc/nginx/sites-enabled/default
         state: absent
       notify: Reload nginx
+
+    - name: Ensure required directories exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0755"
+      loop:
+        - /etc/consul.d
+        - /etc/consul-template.d
+        - /etc/nginx/conf.d
+
+    - name: Drop systemd unit for consul-template
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/consul-template.service
+        mode: "0644"
+        content: |
+          [Unit]
+          Description=Consul Template service for Nginx upstream auto-update
+          After=network-online.target consul.service
+          Wants=network-online.target
+
+          [Service]
+          User=root
+          Group=root
+
+          ExecStart=/usr/local/bin/consul-template \
+            -config=/etc/consul-template.d/frontend-lb-template.hcl
+
+          Restart=on-failure
+          RestartSec=5s
+
+          [Install]
+          WantedBy=multi-user.target
+
+    - name: Drop Consul config (LB agent)
+      ansible.builtin.copy:
+        dest: /etc/consul.d/consul.hcl
+        mode: "0644"
+        content: |
+          datacenter = "my-dc-1"
+
+          data_dir = "/opt/consul"
+
+          client_addr = "0.0.0.0"
+
+          ui_config{
+            enabled = true
+          }
+
+          service {
+            name = "load-balancer"
+            id   = "load-balancer-{id}"
+            port = 80
+          }
+
+          server = false
+
+          bind_addr = "[::]"
+          bind_addr = "0.0.0.0"
+
+          advertise_addr = "ip_addr"
+          retry_join = ["consul.service.consul"]
+
+    - name: Drop nginx consul-template file (frontend-lb-conf.ctmpl)
+      ansible.builtin.copy:
+        dest: /etc/nginx/conf.d/frontend-lb-conf.ctmpl
+        mode: "0644"
+        content: |
+          upstream frontend {
+            {{ range service "frontend" -}}
+            server {{ .Address }}:{{ .Port }};
+            {{ end }}
+          }
+
+          server {
+              listen 80;
+              location / {
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_pass http://frontend;
+              }
+          }
+
+    - name: Drop consul-template config (frontend-lb-template.hcl)
+      ansible.builtin.copy:
+        dest: /etc/consul-template.d/frontend-lb-template.hcl
+        mode: "0644"
+        content: |
+          template {
+            source      = "/etc/nginx/conf.d/frontend-lb-conf.ctmpl"
+            destination = "/etc/nginx/conf.d/lb.conf"
+            command     = "nginx -s reload"
+          }
+
+    - name: Reload systemd to register consul-template service
+      ansible.builtin.systemd:
+        daemon_reload: true
+
+    - name: Enable and start consul-template service
+      ansible.builtin.systemd:
+        name: consul-template
+        enabled: true
+        state: started
+
+    - name: Ensure consul service is started
+      ansible.builtin.systemd:
+        name: consul
+        enabled: true
+        state: started   
 
   handlers:
     - name: Reload nginx


### PR DESCRIPTION
## What was done in PR?
Add consul playbook
Add consul configurations to flask playbook
Add consul configuration to Lb playbook

## Why this PR is required?

Service discovery & auto-scaling: new frontend nodes auto-register in Consul and are picked up by LB without re-running Ansible.
Reliability: passive failover via Nginx + dynamic backend list from Consul.
Consistency & automation: standardized Consul config across server, frontends, and LB.


## How to validate this PR?
Verifiy consul services 
consul catalog services
consul catalog nodes -service frontend

## Additional information
