### PR TITLE
Hp 59 integrate tf lint configuration and linting for terraform modules

### DIFF
--- a/.github/workflows/TFLint.yml
+++ b/.github/workflows/TFLint.yml
@@ -26,8 +26,7 @@ jobs:
     - name: Init TFLint
       run: tflint --init
       env:
-        # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
         GITHUB_TOKEN: ${{ github.token }}
 
     - name: Run TFLint
-      run: tflint --recursive -f compact
+      run: tflint --recursive -f compact --minimum-failure-severity=error

--- a/.github/workflows/TFLint.yml
+++ b/.github/workflows/TFLint.yml
@@ -1,0 +1,33 @@
+name: Lint
+on:
+  push:
+      paths:
+      - '**/*.tf'
+      - '.tflint.hcl'
+  pull_request:
+      paths:
+      - '**/*.tf'
+      - '.tflint.hcl'
+
+jobs:
+  tflint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      name: Checkout source code
+
+    - uses: terraform-linters/setup-tflint@v6
+      name: Setup TFLint
+      with:
+        tflint_version: latest
+        cache: true
+
+    - name: Init TFLint
+      run: tflint --init
+      env:
+        # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
+        GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Run TFLint
+      run: tflint --recursive -f compact

--- a/.github/workflows/TFLint.yml
+++ b/.github/workflows/TFLint.yml
@@ -3,7 +3,7 @@ on:
   push:
       paths:
       - '**/*.tf'
-      - '.tflint.hcl'
+      - 'terraform/.tflint.hcl'
   pull_request:
       paths:
       - '**/*.tf'

--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -12,3 +12,4 @@ plugin "aws" {
     version = "0.43.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
+#test

--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -12,4 +12,4 @@ plugin "aws" {
     version = "0.43.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
-#test
+#test2

--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -12,4 +12,3 @@ plugin "aws" {
     version = "0.43.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
-#test2


### PR DESCRIPTION
## What was done in PR?
Added GitHub Actions workflow to automatically run TFLint on Terraform files
for both push and pull request events

## Why this PR is required?
To setup automatic tflint analyses for terraform files to detect syntax issues

## How to validate this PR?
- Check GitHub Actions → **TFLint** workflow.
- Ensure the job ran successfully and all steps passed.
- Pipeline must show green status (no errors).
## Additional information
TFLint configure file is in /terraform directory and validates all directories recursively 