### PR TITLE
HP-65-implement aws security secret manager on ec2 instance with jenkins for protect connection

### DIFF
--- a/terraform/deploy-vpc-jenkins/install_jenkins.sh
+++ b/terraform/deploy-vpc-jenkins/install_jenkins.sh
@@ -45,9 +45,16 @@ function terraform_setup {
 
 function aws_setup {
     sudo yum install -y unzip curl
+
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
     unzip awscliv2.zip
     sudo ./aws/install
+}
+
+function ssm_agent_setup {
+    yum install -y amazon-ssm-agent
+    systemctl enable amazon-ssm-agent
+    systemctl start amazon-ssm-agent
 }
 
 
@@ -55,6 +62,8 @@ function main {
     jenkins_setup
     ansible_setup
     terraform_setup
+    aws_setup
+    ssm_agent_setup
 }
 
 main

--- a/terraform/deploy-vpc-jenkins/main.tf
+++ b/terraform/deploy-vpc-jenkins/main.tf
@@ -14,18 +14,16 @@ resource "aws_vpc" "main" {
   }
 }
 
-
 resource "aws_subnet" "public" {
   vpc_id                  = aws_vpc.main.id
   cidr_block              = "10.0.1.0/24"
   availability_zone       = "eu-north-1a"
   map_public_ip_on_launch = true
 
-  tags = { 
+  tags = {
     Name = "jenkins-public-subnet" 
   }
 }
-
 
 resource "aws_subnet" "private_1" {
   vpc_id            = aws_vpc.main.id
@@ -34,7 +32,7 @@ resource "aws_subnet" "private_1" {
 
   tags = {
     Name = "private-1"
-  }
+    }
 }
 
 resource "aws_subnet" "private_2" {
@@ -53,7 +51,7 @@ resource "aws_subnet" "private_3" {
   availability_zone = "eu-north-1c"
 
   tags = {
-    Name = "private-3"
+    Name = "private-3" 
   }
 }
 
@@ -80,19 +78,19 @@ resource "aws_subnet" "private_5" {
 
 resource "aws_internet_gateway" "igw" {
   vpc_id = aws_vpc.main.id
+
   tags = {
-    Name = "jenkins-igw"
+    Name = "jenkins-igw" 
   }
 }
-
 
 resource "aws_eip" "nat_eip" {
   domain = "vpc"
-  tags = {
-    Name = "jenkins-nat-eip"
+
+  tags = { 
+    Name = "jenkins-nat-eip" 
   }
 }
-
 
 resource "aws_nat_gateway" "nat" {
   allocation_id = aws_eip.nat_eip.id
@@ -106,7 +104,6 @@ resource "aws_nat_gateway" "nat" {
 
 resource "aws_route_table" "public" {
   vpc_id = aws_vpc.main.id
-
   route {
     cidr_block = "0.0.0.0/0"
     gateway_id = aws_internet_gateway.igw.id
@@ -117,16 +114,13 @@ resource "aws_route_table" "public" {
   }
 }
 
-
 resource "aws_route_table_association" "public_assoc" {
   subnet_id      = aws_subnet.public.id
   route_table_id = aws_route_table.public.id
 }
 
-
 resource "aws_route_table" "private" {
   vpc_id = aws_vpc.main.id
-
   route {
     cidr_block     = "0.0.0.0/0"
     nat_gateway_id = aws_nat_gateway.nat.id
@@ -136,6 +130,7 @@ resource "aws_route_table" "private" {
     Name = "private-rt"
   }
 }
+
 
 resource "aws_route_table_association" "private_assoc_1" {
   subnet_id      = aws_subnet.private_1.id
@@ -166,18 +161,10 @@ resource "aws_route_table_association" "private_assoc_5" {
 resource "aws_security_group" "jenkins_sg" {
   name        = "jenkins-sg"
   vpc_id      = aws_vpc.main.id
-  description = "Allow SSH, ICMP, Jenkins"
 
   ingress {
     from_port   = 22
     to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port   = 8080
-    to_port     = 8080
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
@@ -196,7 +183,38 @@ resource "aws_security_group" "jenkins_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = { Name = "jenkins-sg" }
+  tags = {
+    Name = "jenkins-sg"
+  }
+}
+
+
+resource "aws_iam_role" "ssm_role" {
+  name = "jenkins-ssm-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+
+    Statement = [{
+      Effect    = "Allow"
+
+      Principal = { 
+        Service = "ec2.amazonaws.com"
+      }
+
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_attach" {
+  role       = aws_iam_role.ssm_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ssm_profile" {
+  name = "jenkins-ssm-profile"
+  role = aws_iam_role.ssm_role.name
 }
 
 
@@ -204,8 +222,9 @@ resource "aws_instance" "jenkins" {
   ami                    = "ami-0a410d510ebdc48ba"
   instance_type          = "t3.medium"
   key_name               = var.key_name
-  subnet_id              = aws_subnet.public.id
+  subnet_id              = aws_subnet.private_5.id
   vpc_security_group_ids = [aws_security_group.jenkins_sg.id]
+  iam_instance_profile   = aws_iam_instance_profile.ssm_profile.name
   user_data              = file("${path.module}/install_jenkins.sh")
 
   root_block_device {
@@ -215,6 +234,6 @@ resource "aws_instance" "jenkins" {
   }
 
   tags = {
-    Name = "Jenkins-Server" 
+    Name = "Jenkins-Server"
   }
 }

--- a/terraform/deploy-vpc-jenkins/outputs.tf
+++ b/terraform/deploy-vpc-jenkins/outputs.tf
@@ -3,12 +3,16 @@ output "vpc_id" {
   value = aws_vpc.main.id
 }
 
-output "jenkins_public_ip" {
-  value = aws_instance.jenkins.public_ip
+output "jenkins_private_ip" {
+  value = aws_instance.jenkins.private_ip
 }
 
 output "jenkins_sg_id" {
   value = aws_security_group.jenkins_sg.id
+}
+
+output "jenkins_instance_id" {
+  value = aws_instance.jenkins.id
 }
 
 output "private_subnet_ids" {
@@ -22,11 +26,9 @@ output "private_subnet_ids" {
 }
 
 output "public_subnet_id" {
-  description = "ID of the public subnet for Jenkins"
-  value       = aws_subnet.public.id
+  value = aws_subnet.public.id
 }
 
 output "private_route_table_id" {
-  description = "ID of the private route table"
   value = aws_route_table.private.id
 }


### PR DESCRIPTION
## What was done in PR?
Impelmented Secret security manager(SSM) AWS with Jenkins EC2 instance to 
## Why this PR is required?
Protect jenkins server from outside login. Public IP-address was replaced
## How to validate this PR?

1. `aws ssm start-session --target <instance_ID>`
2. `aws ssm start-session --target <instance_ID> --document-name AWS-StartPortForwardingSession --parameters "{\"portNumber\":[\"8080\"], \"localPortNumber\":[\"8080\"]}" --region eu-north-1`
3. `aws ssm start-session --target i-094beacdbead55bb7 --document-name AWS-StartPortForwardingSession --parameters "{\"portNumber\":[\"22\"], \"localPortNumber\":[\"2222\"]}" --region eu-north-1`


## Additional information
