### PR TITLE
HP-66 Added script to setup consul dns in packer

### DIFF
--- a/aws-packer/base/additional-files/consul-dns.conf
+++ b/aws-packer/base/additional-files/consul-dns.conf
@@ -1,0 +1,4 @@
+[Resolve]
+DNS=127.0.0.1
+DNSSEC=false
+Domains=~consul

--- a/aws-packer/base/build-base.pkr.hcl
+++ b/aws-packer/base/build-base.pkr.hcl
@@ -13,4 +13,13 @@ build {
     provisioner "shell" {
         script = "scripts/install-consul.sh"
     }
+
+    provisioner "file" {
+        source = "additional-files/consul-dns.conf"
+        destination = "/tmp/consul.conf"
+    }
+
+    provisioner "shell" {
+        script = "scripts/setup-consul-dns.sh"
+    }
 }

--- a/aws-packer/base/scripts/base-tools.sh
+++ b/aws-packer/base/scripts/base-tools.sh
@@ -4,4 +4,5 @@ sudo dnf -y update
 
 sudo dnf -y install \
   wget unzip tar gzip \
-  htop lsof jq net-tools vim nano
+  htop lsof jq net-tools \
+  vim nano iptables

--- a/aws-packer/base/scripts/setup-consul-dns.sh
+++ b/aws-packer/base/scripts/setup-consul-dns.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+sudo mkdir /etc/systemd/resolved.conf.d/
+
+sudo mv /tmp/consul.conf /etc/systemd/resolved.conf.d/consul.conf
+
+sudo iptables --table nat --append OUTPUT --destination localhost --protocol udp --match udp --dport 53 --jump REDIRECT --to-ports 8600
+sudo iptables --table nat --append OUTPUT --destination localhost --protocol tcp --match tcp --dport 53 --jump REDIRECT --to-ports 8600
+
+sudo systemctl restart systemd-resolved


### PR DESCRIPTION
## What was done in PR?
It's configure DNS in host, that allow using consul DNS, so servers can use service discovery to talk with each otherю 

## Why this PR is required?
Because that allow our hosts to talk with another hosts, without hard-coding ip addresses

## How to validate this PR?
Try to run some VMs, and create cluster in consul with different services on different hosts, and then try to ping some of them using consul DNS, for example: ping frontend.service.consul

## Additional information
