### PR TITLE
Hp 69 update terraform ec2 to new ami v2

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,2 @@
+.terraform*
+terraform.tfstate*

--- a/terraform/deploy-consul/main.tf
+++ b/terraform/deploy-consul/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
 
 resource "aws_instance" "consul" {
-  ami                    = "ami-0a410d510ebdc48ba"
+  ami                    = "ami-0befc82ff063f118b"
   instance_type          = "t3.micro"
   subnet_id              = var.private_subnet_ids[0]
   key_name               = var.key_name

--- a/terraform/deploy-servers/main.tf
+++ b/terraform/deploy-servers/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
 
 resource "aws_instance" "database" {
-  ami                    = "ami-0a410d510ebdc48ba"
+  ami                    = "ami-0befc82ff063f118b"
   instance_type          = "t3.micro"
   subnet_id              = var.private_subnet_ids[1]
   key_name               = var.key_name
@@ -18,7 +18,7 @@ resource "aws_instance" "database" {
 }
 
 resource "aws_instance" "flask_1" {
-  ami                    = "ami-08a686a69a7bf216e"
+  ami                    = "ami-0518861cac9f0c37a"
   instance_type          = "t3.micro"
   subnet_id              = var.private_subnet_ids[2]
   key_name               = var.key_name
@@ -33,7 +33,7 @@ resource "aws_instance" "flask_1" {
 }
 
 resource "aws_instance" "flask_2" {
-  ami                    = "ami-08a686a69a7bf216e"
+  ami                    = "ami-0518861cac9f0c37a"
   instance_type          = "t3.micro"
   subnet_id              = var.private_subnet_ids[3]
   key_name               = var.key_name
@@ -48,7 +48,7 @@ resource "aws_instance" "flask_2" {
 }
 
 resource "aws_instance" "loadbalancer" {
-  ami                    = "ami-0a410d510ebdc48ba"
+  ami                    = "ami-0befc82ff063f118b"
   instance_type          = "t3.micro"
   subnet_id              = var.public_subnet_id
   key_name               = var.key_name

--- a/terraform/deploy-vpc-jenkins/main.tf
+++ b/terraform/deploy-vpc-jenkins/main.tf
@@ -201,7 +201,7 @@ resource "aws_security_group" "jenkins_sg" {
 
 
 resource "aws_instance" "jenkins" {
-  ami                    = "ami-0a410d510ebdc48ba"
+  ami                    = "ami-0befc82ff063f118b"
   instance_type          = "t3.medium"
   key_name               = var.key_name
   subnet_id              = aws_subnet.public.id


### PR DESCRIPTION
## What was done in PR?
Updated AMI's id to v2.

## Why this PR is required?
We move to newer version of images.

## How to validate this PR?
Run terraform. Join vms to consul cluster. ping frontend.service.consul, or any other service.

## Additional information
