### PR TITLE
HP-72 Saving iptables rules in config file

### DIFF
--- a/aws-packer/base/scripts/base-tools.sh
+++ b/aws-packer/base/scripts/base-tools.sh
@@ -5,4 +5,4 @@ sudo dnf -y update
 sudo dnf -y install \
   wget unzip tar gzip \
   htop lsof jq net-tools \
-  vim nano iptables
+  vim nano iptables iptables-services

--- a/aws-packer/base/scripts/setup-consul-dns.sh
+++ b/aws-packer/base/scripts/setup-consul-dns.sh
@@ -7,4 +7,7 @@ sudo mv /tmp/consul.conf /etc/systemd/resolved.conf.d/consul.conf
 sudo iptables --table nat --append OUTPUT --destination localhost --protocol udp --match udp --dport 53 --jump REDIRECT --to-ports 8600
 sudo iptables --table nat --append OUTPUT --destination localhost --protocol tcp --match tcp --dport 53 --jump REDIRECT --to-ports 8600
 
+sudo service iptables save
+
+sudo systemctl enable --now iptables
 sudo systemctl restart systemd-resolved


### PR DESCRIPTION
## What was done in PR?
Fixed bug with disappearing iptables rules

## Why this PR is required?
Because without it we have manualy to add and save rules

## How to validate this PR?
Create AMI, and vm's using this ami, login into VM, run `sudo cat /etc/sysconfig/iptables` if you see some text, then everything is okay

## Additional information
