### PR TITLE
Hp 70 add rules to ec2 in terraform that allow access to default consul ports

### DIFF
--- a/terraform/deploy-consul/main.tf
+++ b/terraform/deploy-consul/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
 
 resource "aws_instance" "consul" {
-  ami                    = "ami-0befc82ff063f118b"
+  ami                    = "ami-00609db54d76c69fd"
   instance_type          = "t3.micro"
   subnet_id              = var.private_subnet_ids[0]
   key_name               = var.key_name

--- a/terraform/deploy-consul/main.tf
+++ b/terraform/deploy-consul/main.tf
@@ -1,6 +1,6 @@
 
 provider "aws" {
-  region = "eu-north-1"
+  region = var.aws_region
 }
 
 
@@ -16,4 +16,20 @@ resource "aws_instance" "consul" {
   tags = { 
     Name = "Consul" 
   }
+}
+
+
+resource "aws_route53_zone" "internal" {
+  name = "internal"
+  vpc {
+    vpc_id = var.vpc_id
+    vpc_region = var.aws_region
+  }
+}
+resource "aws_route53_record" "consul_internal" {
+  zone_id = aws_route53_zone.internal.zone_id
+  name    = "consul.internal" 
+  type    = "A"
+  ttl     = "300"
+  records = [aws_instance.consul.private_ip]
 }

--- a/terraform/deploy-consul/variables.tf
+++ b/terraform/deploy-consul/variables.tf
@@ -23,3 +23,8 @@ variable "public_subnet_id" {
   type        = string
   description = "Public subnet ID for Load Balancer"
 }
+
+variable "aws_region" {
+  type = string
+  default = "eu-north-1"
+}

--- a/terraform/deploy-servers/main.tf
+++ b/terraform/deploy-servers/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
 
 resource "aws_instance" "database" {
-  ami                    = "ami-0befc82ff063f118b"
+  ami                    = "ami-00609db54d76c69fd"
   instance_type          = "t3.micro"
   subnet_id              = var.private_subnet_ids[1]
   key_name               = var.key_name
@@ -18,7 +18,7 @@ resource "aws_instance" "database" {
 }
 
 resource "aws_instance" "flask_1" {
-  ami                    = "ami-0518861cac9f0c37a"
+  ami                    = "ami-0fcf898ba974a77f1"
   instance_type          = "t3.micro"
   subnet_id              = var.private_subnet_ids[2]
   key_name               = var.key_name
@@ -33,7 +33,7 @@ resource "aws_instance" "flask_1" {
 }
 
 resource "aws_instance" "flask_2" {
-  ami                    = "ami-0518861cac9f0c37a"
+  ami                    = "ami-0fcf898ba974a77f1"
   instance_type          = "t3.micro"
   subnet_id              = var.private_subnet_ids[3]
   key_name               = var.key_name
@@ -48,7 +48,7 @@ resource "aws_instance" "flask_2" {
 }
 
 resource "aws_instance" "loadbalancer" {
-  ami                    = "ami-0befc82ff063f118b"
+  ami                    = "ami-00609db54d76c69fd"
   instance_type          = "t3.micro"
   subnet_id              = var.public_subnet_id
   key_name               = var.key_name

--- a/terraform/deploy-vpc-jenkins/main.tf
+++ b/terraform/deploy-vpc-jenkins/main.tf
@@ -201,7 +201,7 @@ resource "aws_security_group" "jenkins_sg" {
 
 
 resource "aws_instance" "jenkins" {
-  ami                    = "ami-0befc82ff063f118b"
+  ami                    = "ami-00609db54d76c69fd"
   instance_type          = "t3.medium"
   key_name               = var.key_name
   subnet_id              = aws_subnet.public.id

--- a/terraform/deploy-vpc-jenkins/main.tf
+++ b/terraform/deploy-vpc-jenkins/main.tf
@@ -166,7 +166,7 @@ resource "aws_route_table_association" "private_assoc_5" {
 resource "aws_security_group" "jenkins_sg" {
   name        = "jenkins-sg"
   vpc_id      = aws_vpc.main.id
-  description = "Allow SSH, ICMP, Jenkins"
+  description = "Allow SSH, ICMP, Jenkins, HTTP/S, Consul"
 
   ingress {
     from_port   = 22
@@ -186,6 +186,62 @@ resource "aws_security_group" "jenkins_sg" {
     from_port   = -1
     to_port     = -1
     protocol    = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "http"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "https"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 8300
+    to_port     = 8300
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 8301
+    to_port     = 8301
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 8301
+    to_port     = 8301
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 8500
+    to_port     = 8500
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 8600
+    to_port     = 8600
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 8600
+    to_port     = 8600
+    protocol    = "udp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 


### PR DESCRIPTION
## What was done in PR?
AMI updated to v3, added ports for http and consul, and route53 private hosted zone with A record to consul

## Why this PR is required?
Its make our infrastructure more scallable and flexible 

## How to validate this PR?

## Additional information
