### PR TITLE
HP-75_Extend_SSD_memory_in_EC2_servers

### DIFF
--- a/terraform/deploy-servers/main.tf
+++ b/terraform/deploy-servers/main.tf
@@ -27,6 +27,12 @@ resource "aws_instance" "flask_1" {
 
   iam_instance_profile = aws_iam_instance_profile.flask_profile.name
 
+  root_block_device {
+    volume_size           = 5
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
+
   tags = {
     Name = "Flask Server 1"
   }
@@ -42,6 +48,12 @@ resource "aws_instance" "flask_2" {
 
   iam_instance_profile = aws_iam_instance_profile.flask_profile.name
 
+  root_block_device {
+    volume_size           = 5
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
+
   tags = {
     Name = "Flask Server 2"
   }
@@ -53,7 +65,14 @@ resource "aws_instance" "loadbalancer" {
   subnet_id              = var.public_subnet_id
   key_name               = var.key_name
   vpc_security_group_ids = [var.jenkins_sg_id]
+  
   associate_public_ip_address = true
+
+  root_block_device {
+    volume_size           = 5
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
 
   tags = {
     Name = "Load Balancer"


### PR DESCRIPTION
## What was done in PR?
Extended SSD memory from tdefault 2 GB ro 5 GB in Flask Server 1, Flask Server 2, Consul Server 

## Why this PR is required
In ability to install or download additional packages on EC2 machines

## How to validate this PR?

## Additional information
Additional g3 SSD automalically destroy with instances