### PR TITLE
Add configs Prometheus and Grafan

### DIFF
--- a/ansible/collections/requirements.yml
+++ b/ansible/collections/requirements.yml
@@ -2,3 +2,4 @@ collections:
   - name: community.postgresql
     version: ">=3.4.0"
   - name: community.general
+  - name: prometheus.prometheus

--- a/ansible/consul.yml
+++ b/ansible/consul.yml
@@ -28,7 +28,35 @@
         name: consul
         enabled: true
         state: started
-      
+
+    - name: Install Prometheus server (with Consul SD)
+      ansible.builtin.import_role:
+        name: prometheus.prometheus.prometheus
+      vars:
+        prometheus_scrape_configs:
+          - job_name: "consul"
+            consul_sd_configs:
+              - server: "localhost:8500"
+                services: []
+
+    - name: Install Grafana (datasource + basic dashboard)
+      ansible.builtin.import_role:
+        name: prometheus.prometheus.grafana
+      vars:
+        grafana_security:
+          admin_user: admin
+          admin_password: "{{grafana_admin_pass}}"
+        grafana_datasources:
+          - name: Prometheus
+            type: prometheus
+            access: proxy
+            url: http://localhost:9090
+            isDefault: true
+        grafana_dashboards:
+          - dashboard_id: 1860
+            revision_id: 33
+            datasource: Prometheus
+
   handlers:
     - name: Restart consul
       service:

--- a/aws-packer/base/build-base.pkr.hcl
+++ b/aws-packer/base/build-base.pkr.hcl
@@ -22,4 +22,8 @@ build {
     provisioner "shell" {
         script = "scripts/setup-consul-dns.sh"
     }
+
+        provisioner "shell" {
+        script = "scripts/install-node-exporter.sh"
+    }
 }

--- a/aws-packer/base/scripts/install-node-exporter.sh
+++ b/aws-packer/base/scripts/install-node-exporter.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+cd /tmp
+wget https://github.com/prometheus/node_exporter/releases/download/v1.8.2/node_exporter-1.8.2.linux-amd64.tar.gz
+
+tar xvf node_exporter-1.8.2.linux-amd64.tar.gz
+
+sudo mv node_exporter-1.8.2.linux-amd64/node_exporter /usr/local/bin/
+
+sudo useradd --no-create-home --shell /sbin/nologin node_exporter || true
+sudo chown node_exporter:node_exporter /usr/local/bin/node_exporter
+
+sudo tee /etc/systemd/system/node_exporter.service > /dev/null <<EOF
+[Unit]
+Description=Prometheus Node Exporter
+After=network.target
+
+[Service]
+User=node_exporter
+ExecStart=/usr/local/bin/node_exporter
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable node_exporter
+sudo systemctl start node_exporter
+
+sudo tee /etc/consul.d/node-exporter.hcl > /dev/null <<'EOF'
+service {
+  name = "node-exporter"
+  port = 9100
+  check {
+    name     = "HTTP check for node-exporter"
+    http     = "http://localhost:9100/metrics"
+    interval = "10s"
+    timeout  = "5s"
+  }
+}
+EOF
+
+sudo consul validate /etc/consul.d/node-exporter.hcl || true


### PR DESCRIPTION
## What was done in PR?
	•	Added Prometheus and Grafana monitoring integration.
	•	Added node_exporter installation to Packer image.
	•	Extended Consul playbook to include Prometheus (server) and Grafana (UI).
	•	Configured Consul Service Discovery, so Prometheus automatically detects exporters.

## Why this PR is required?
	•	To enable system-level monitoring for all servers (CPU, memory, disk, network).
	•	Provides a central Grafana dashboard for visibility into infrastructure health.
	•	Simplifies setup — all exporters discovered automatically through Consul.

## How to validate this PR?
	•	Check Prometheus UI:
	•	Open http://<consul_ip>:9090/targets
	•	All targets should show status UP
	•	Open Grafana:
	•	Go to http://localhost:3000 (via SSH tunnel or VPN)
	•	Login with credentials → admin / <your_password>
	•	Open dashboard “Node Exporter Full (1860)”
	•	Metrics should be visible for all nodes
## Additional information
	•	Grafana password provided securely from Jenkins Credentials.
	•	Future steps: add alert rules and exporters for DB, Nginx, and app metrics.
